### PR TITLE
Fix "./dev tests"

### DIFF
--- a/cpi/drilldown/drilldown_model.py
+++ b/cpi/drilldown/drilldown_model.py
@@ -84,7 +84,7 @@ class DrilldownModel(object):
     def calc_percentage(count, total_count, percent_factor=100):
         """ Calculate the percentage for a specific count
         in proportion to the total, using the percent factor """
-        percentage = Decimal(float(count) * percent_factor / total_count)
+        percentage = Decimal(float(count) * float(percent_factor) / total_count)
         percentage = round(percentage, 2)
         return percentage
 

--- a/cpi/drilldown/drilldown_view.py
+++ b/cpi/drilldown/drilldown_view.py
@@ -51,22 +51,22 @@ class DrilldownView(object):
                 if print_binmodule:
                     # If not the first element, print a new line
                     if ui_binmodule is not ui_binmodule_list[0]:
-                        print ""
-                    print ui_binmodule.get_text()
+                        print()
+                    print(ui_binmodule.get_text())
                     print_binmodule = False
-                print TABULATION + ui_symbol.get_text()
+                print(TABULATION + ui_symbol.get_text())
                 # For each sample
                 for ui_sample in ui_symbol.get_samples_list():
-                    print TABULATION + TABULATION + ui_sample.get_text()
+                    print(TABULATION + TABULATION + ui_sample.get_text())
         print border + "\n"
 
     @staticmethod
     def __print_logo(title, border):
         """ Print the drilldown logo """
-        print ""
-        print border
-        print title
-        print border
+        print()
+        print(border)
+        print(title)
+        print(border)
 
     @staticmethod
     def __get_border(title):

--- a/cpi/drilldown/opreport_parser.py
+++ b/cpi/drilldown/opreport_parser.py
@@ -144,8 +144,9 @@ class OpreportParser(object):
                     ddata = detaildata_list[index]
                     detaildata.set_count(count + ddata.get_count())
                     del detaildata_list[index]
-                    detaildata_list.append(detaildata)
                 else:
                     symbol_details = opreport_model.SymbolDetails(i,
                                                                   detaildata_list)
                     self.symboldetail_list.append(symbol_details)
+
+                detaildata_list.append(detaildata)

--- a/tests/drilldown_tests/drilldown_model_test.py
+++ b/tests/drilldown_tests/drilldown_model_test.py
@@ -38,8 +38,8 @@ class DrilldownModelTest(unittest.TestCase):
         super(DrilldownModelTest, self).__init__(*args, **kwargs)
 
     def binmodule_test(self):
-        expected_binmodules = ["85.3% in /usr/lib64/power8/libc-2.17.so",
-                               "14.5% in /home/iplsdk/sync-rhel/main.x",
+        expected_binmodules = ["85.30% in /usr/lib64/power8/libc-2.17.so",
+                               "14.50% in /home/iplsdk/sync-rhel/main.x",
                                "0.18% in /no-vmlinux",
                                "0.02% in /usr/lib64/ld-2.17.so"]
 
@@ -58,7 +58,7 @@ class DrilldownModelTest(unittest.TestCase):
             "1.25% in 00000037.plt_call.rand@@GLIBC_2.17 [??]"]
 
         expected_samples = ["3.84% on line 32",
-                            "2.5% on line 30",
+                            "2.50% on line 30",
                             "2.39% on line 31"]
 
         # Get symbols from the binary element


### PR DESCRIPTION
Several fixes bundled:

- In `opreport_parser.py`, a serious bug where `detaildata` was never
  appended to any lists
- A missed conversion from `Decimal` to `float` in
  `DrilldownModel::calc_percentage`
- A couple of minor formatting errors in `drilldown_model_test.py`
- Some lingering conversions to Python3's `print` function

Signed-off-by: Caedan Clarke <caedanzclarke@gmail.com>
Signed-off-by: Paul Clarke <pc@us.ibm.com>